### PR TITLE
change Kaldi website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ not very portable, so I made these so anyone can get up and running quickly.
 ### Shared vs. Static
 
 Kaldi can be built with either static (default) or shared libraries [see
-breakdown](http://kaldi.sourceforge.net/build_setup.html). As such, there are
+breakdown](http://kaldi-asr.org/doc/build_setup.html). As such, there are
 two available base images to work from:
 
 - `jbender/kaldi-static` which uses static libraries and is ~7.7 GB


### PR DESCRIPTION
I've just changed the link to 'The build process' page on Kaldi website as it moved to `http://kaldi-asr.org/doc/build_setup.html`.